### PR TITLE
Updated to new repo name

### DIFF
--- a/camp.nook.nookdesktop.appdata.xml
+++ b/camp.nook.nookdesktop.appdata.xml
@@ -26,7 +26,7 @@
     </ul>
   </description>
   <url type="homepage">https://nook.camp</url>
-  <url type="bugtracker">https://github.com/OpenSauce04/nook-desktop/issues</url>
+  <url type="bugtracker">https://github.com/OpenSauce04/nook-desktop-flatpak</url>
   <launchable type="desktop-id">camp.nook.nookdesktop.desktop</launchable>
   <screenshots>
     <screenshot type="default">

--- a/camp.nook.nookdesktop.yml
+++ b/camp.nook.nookdesktop.yml
@@ -61,7 +61,7 @@ modules:
     sources:
 
       - type: git
-        url: https://github.com/OpenSauce04/nook-desktop.git
+        url: https://github.com/OpenSauce04/nook-desktop-flatpak.git
         commit: bd167b53f8d39264b82e9283383e0c50e9f0c8d8
         dest: main
 


### PR DESCRIPTION
This is to keep the flatpak repo seperate from my upstream contribution branches