### PR TITLE
Update to version v1.0.9-f2

### DIFF
--- a/camp.nook.nookdesktop.appdata.xml
+++ b/camp.nook.nookdesktop.appdata.xml
@@ -34,7 +34,15 @@
     </screenshot>
   </screenshots>
   <releases>
+
+    <release version="1.0.9-f2" date="2023-06-05">
+      <description>
+        <p>- When running on the Gnome desktop environment, the minimize to tray button is no longer visible</p>
+      </description>
+    </release>
+
     <release version="1.0.9-f1" date="2023-05-25"/>
+
   </releases>
   <keywords>
     <keyword>nook</keyword>

--- a/camp.nook.nookdesktop.yml
+++ b/camp.nook.nookdesktop.yml
@@ -62,7 +62,7 @@ modules:
 
       - type: git
         url: https://github.com/OpenSauce04/nook-desktop.git
-        commit: bd167b53f8d39264b82e9283383e0c50e9f0c8d8
+        commit: 1dc6365768662e095fcb2e80666bf3d5836d5bf6
         dest: main
 
       - type: file


### PR DESCRIPTION
Changes:
- When running on the Gnome desktop environment, the minimize to tray button is no longer visible