### PR TITLE
Update Flatpak runtime dependencies

### DIFF
--- a/camp.nook.nookdesktop.appdata.xml
+++ b/camp.nook.nookdesktop.appdata.xml
@@ -30,6 +30,7 @@
   <launchable type="desktop-id">camp.nook.nookdesktop.desktop</launchable>
   <screenshots>
     <screenshot type="default">
+      <caption>An image showing various menus from Nook Desktop</caption>
       <image>https://github-production-user-asset-6210df.s3.amazonaws.com/48618519/240965032-dff9d5b9-a99d-421d-b5fe-eba5a5a7686d.png</image>
     </screenshot>
   </screenshots>

--- a/camp.nook.nookdesktop.appdata.xml
+++ b/camp.nook.nookdesktop.appdata.xml
@@ -2,6 +2,9 @@
 <component type="desktop-application">
   <id>camp.nook.nookdesktop</id>
   <name>Nook Desktop</name>
+  <developer id="dog.mat">
+    <name>mn6</name>
+  </developer>
   <project_license>ISC</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <summary>Nook is an application that plays Animal Crossing hourly themes on the hour.</summary>

--- a/camp.nook.nookdesktop.appdata.xml
+++ b/camp.nook.nookdesktop.appdata.xml
@@ -4,9 +4,6 @@
   <name>Nook Desktop</name>
   <project_license>ISC</project_license>
   <metadata_license>CC0-1.0</metadata_license>
-  <provides>
-    <id>camp.nook.nookdesktop</id>
-  </provides>
   <summary>Nook is an application that plays Animal Crossing hourly themes on the hour.</summary>
   <description>
     <p>Nook used to be a browser extension, however with the changes bought in Chrome Manifest v3, it was decided that the browser extension was too difficult to maintain, and Nook was repurposed into a desktop app.</p>

--- a/camp.nook.nookdesktop.yml
+++ b/camp.nook.nookdesktop.yml
@@ -1,12 +1,12 @@
 app-id: camp.nook.nookdesktop
 
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '24.08'
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.node18
+  - org.freedesktop.Sdk.Extension.node20
 
 command: run.sh
 separate-locales: false
@@ -21,7 +21,7 @@ finish-args:
   - --socket=pulseaudio
 
 build-options:
-  append-path: /usr/lib/sdk/node18/bin
+  append-path: /usr/lib/sdk/node20/bin
   env:
     NPM_CONFIG_LOGLEVEL: info
 


### PR DESCRIPTION
The Freedesktop Flatpak runtime version 22.08 has gone EOL, so this updates the runtime version to 24.08.
The NodeJS version has also been bumped from Node 18 to Node 20 for the same reason